### PR TITLE
build: add check to enforce max allowed terraform version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@
 PROJECT_NAME ?= upjet-provider-template
 PROJECT_REPO ?= github.com/upbound/$(PROJECT_NAME)
 
-export TERRAFORM_VERSION ?= 1.2.1
+export TERRAFORM_VERSION ?= 1.5.7
+
+# Do not allow a version of terraform greater than 1.5.x, due to versions 1.6+ being
+# licensed under BSL, which is not permitted.
+export TERRAFORM_VERSION_CEILING ?= 1.6
+TERRAFORM_VERSION_VALID := $(shell [ $(TERRAFORM_VERSION) = `echo "$(TERRAFORM_VERSION)\n$(TERRAFORM_VERSION_CEILING)" | sort -V | head -n1` ] && echo 1 || echo 0)
 
 export TERRAFORM_PROVIDER_SOURCE ?= hashicorp/null
 export TERRAFORM_PROVIDER_REPO ?= https://github.com/hashicorp/terraform-provider-null
@@ -93,7 +98,7 @@ xpkg.build.upjet-provider-template: do.build.images
 
 # NOTE(hasheddan): we ensure up is installed prior to running platform-specific
 # build steps in parallel to avoid encountering an installation race condition.
-build.init: $(UP)
+build.init: $(UP) check-terraform-version
 
 # ====================================================================================
 # Setup Terraform for fetching provider schema
@@ -101,7 +106,12 @@ TERRAFORM := $(TOOLS_HOST_DIR)/terraform-$(TERRAFORM_VERSION)
 TERRAFORM_WORKDIR := $(WORK_DIR)/terraform
 TERRAFORM_PROVIDER_SCHEMA := config/schema.json
 
-$(TERRAFORM):
+check-terraform-version:
+ifneq ($(TERRAFORM_VERSION_VALID),1)
+	$(error invalid TERRAFORM_VERSION $(TERRAFORM_VERSION), must be less than $(TERRAFORM_VERSION_CEILING))
+endif
+
+$(TERRAFORM): check-terraform-version
 	@$(INFO) installing terraform $(HOSTOS)-$(HOSTARCH)
 	@mkdir -p $(TOOLS_HOST_DIR)/tmp-terraform
 	@curl -fsSL https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_$(SAFEHOST_PLATFORM).zip -o $(TOOLS_HOST_DIR)/tmp-terraform/terraform.zip
@@ -127,7 +137,7 @@ pull-docs:
 
 generate.init: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs
 
-.PHONY: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs
+.PHONY: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs check-terraform-version
 # ====================================================================================
 # Targets
 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ export TERRAFORM_VERSION ?= 1.5.7
 
 # Do not allow a version of terraform greater than 1.5.x, due to versions 1.6+ being
 # licensed under BSL, which is not permitted.
-export TERRAFORM_VERSION_CEILING ?= 1.6
-TERRAFORM_VERSION_VALID := $(shell [ $(TERRAFORM_VERSION) = `echo "$(TERRAFORM_VERSION)\n$(TERRAFORM_VERSION_CEILING)" | sort -V | head -n1` ] && echo 1 || echo 0)
+TERRAFORM_VERSION_VALID := $(shell [ "$(TERRAFORM_VERSION)" = "`printf "$(TERRAFORM_VERSION)\n1.6" | sort -V | head -n1`" ] && echo 1 || echo 0)
 
 export TERRAFORM_PROVIDER_SOURCE ?= hashicorp/null
 export TERRAFORM_PROVIDER_REPO ?= https://github.com/hashicorp/terraform-provider-null
@@ -108,7 +107,7 @@ TERRAFORM_PROVIDER_SCHEMA := config/schema.json
 
 check-terraform-version:
 ifneq ($(TERRAFORM_VERSION_VALID),1)
-	$(error invalid TERRAFORM_VERSION $(TERRAFORM_VERSION), must be less than $(TERRAFORM_VERSION_CEILING))
+	$(error invalid TERRAFORM_VERSION $(TERRAFORM_VERSION), must be less than 1.6.0 since that version introduced a not permitted BSL license))
 endif
 
 $(TERRAFORM): check-terraform-version


### PR DESCRIPTION
### Description of your changes

This PR adds a new check to the `Makefile` that enforces the `TERRAFORM_VERSION` cannot be set to something higher than `1.5.x`. Starting with v1.6, Terraform started being licensed under the BSL, which is not a permitted license for the Crossplane project.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have run various `make` commands, such as `make reviewable` and `make`, with various test values and observed the behavior in the table below.  Versions below 1.6 are built successfully and versions greater than or equal to 1.6 will fail and stop the build.

| `TERRAFORM_VERSION` | command | result |
| ------------------------- | ---------- | ------ |
| `1.5.7` | `make` | OK |
| `1.5.7` | `make reviewable` | OK | 
| `1.6.0` | `make` | `Makefile:111: *** invalid TERRAFORM_VERSION 1.6.0, must be less than 1.6.  Stop.` |
| `1.8.4` | `make reviewable` | `Makefile:111: *** invalid TERRAFORM_VERSION 1.8.4, must be less than 1.6.  Stop.` | 

[contribution process]: https://git.io/fj2m9
