### PR TITLE
add support for non-interactive usage

### DIFF
--- a/hack/prepare.sh
+++ b/hack/prepare.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
-read -r -p "Lower case provider name (ex. github): " PROVIDER_NAME_LOWER
-read -r -p "Normal case provider name (ex. GitHub): " PROVIDER_NAME_NORMAL
-read -r -p "Organization (ex. upbound, my-org-name): " ORGANIZATION_NAME
-read -r -p "CRD rootGroup (ex. upbound.io, crossplane.io): " CRD_ROOT_GROUP
+: ${PROVIDER_NAME_LOWER:=$(read -r -p "Lower case provider name (ex. github): " PROVIDER_NAME_LOWER; echo -n "${PROVIDER_NAME_LOWER}")}
+: ${PROVIDER_NAME_NORMAL:=$(read -r -p "Normal case provider name (ex. GitHub): " PROVIDER_NAME_NORMAL; echo -n "${PROVIDER_NAME_NORMAL}")}
+: ${ORGANIZATION_NAME:=$(read -r -p "Organization (ex. upbound, my-org-name): " ORGANIZATION_NAME; echo -n "${ORGANIZATION_NAME}")}
+: ${CRD_ROOT_GROUP:=$(read -r -p "CRD rootGroup (ex. upbound.io, crossplane.io): " CRD_ROOT_GROUP; echo -n "${CRD_ROOT_GROUP}")}
 
 REPLACE_FILES='./* ./.github :!build/** :!go.* :!hack/prepare.sh'
 # shellcheck disable=SC2086


### PR DESCRIPTION

### Description of your changes

a small change to allow the script to work in non-interactive contexts by allowing the values that would be read from STDIN to be provided by environment, and falling back to the previous behaviour when undefined.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.
  - _No, because this target did not appear to be present in the Makefile._

### How has this code been tested

Ran `hack/prepare.sh` both with and without environment variables set, observed that the variables are set equivalently either way.
