### PR TITLE
hotfix: add essTLSCertsPath to create ESSOptions to protect against panic seg…

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -6,10 +6,11 @@ package main
 
 import (
 	"context"
-	"github.com/crossplane/crossplane-runtime/pkg/certificates"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/crossplane/crossplane-runtime/pkg/certificates"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	xpcontroller "github.com/crossplane/crossplane-runtime/pkg/controller"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

When activating `--enable-external-secret-stores` the controller will fails with this error:

```bash
2024-09-24T09:31:37Z	DEBUG	provider-ovh	Starting	{"sync-period": "1h0m0s", "poll-interval": "10m0s", "max-reconcile-rate": 10}
2024-09-24T09:31:37Z	INFO	provider-ovh	Alpha feature enabled	{"flag": "EnableAlphaExternalSecretStores"}
2024-09-24T09:31:37Z	INFO	provider-ovh	Beta feature enabled	{"flag": "EnableBetaManagementPolicies"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x16c1c20]

goroutine 1 [running]:
github.com/edixos/provider-ovh/internal/controller/additionalip/move.Setup({0x203f2a0, 0x400032f860}, {{{0x2021a30, 0x40002d55f0}, {0x2021a00, 0x40008001a8}, 0x8bb2c97000, 0xa, 0x40003ac660, 0x0}, ...})
	github.com/edixos/provider-ovh/internal/controller/additionalip/move/zz_controller.go:33 +0x260
github.com/edixos/provider-ovh/internal/controller.Setup({0x203f2a0, 0x400032f860}, {{{0x2021a30, 0x40002d55f0}, {0x2021a00, 0x40008001a8}, 0x8bb2c97000, 0xa, 0x40003ac660, 0x0}, ...})
	github.com/edixos/provider-ovh/internal/controller/zz_setup.go:193 +0x4ac
main.main()
	github.com/edixos/provider-ovh/cmd/provider/main.go:122 +0x1dfc
```
This is happening because of `o.ESSOptions` is nil when running the controller. 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally with `provider-ovh` generated from this template.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
