### PR TITLE
fix EOF and root CRD

### DIFF
--- a/cluster/test/setup.sh
+++ b/cluster/test/setup.sh
@@ -24,3 +24,7 @@ spec:
       name: provider-secret
       namespace: upbound-system
       key: credentials
+EOF
+
+${KUBECTL} wait provider.pkg --all --for condition=Healthy --timeout 5m
+${KUBECTL} -n upbound-system wait --for=condition=Available deployment --all --timeout=5m

--- a/hack/prepare.sh
+++ b/hack/prepare.sh
@@ -18,6 +18,8 @@ git grep -l 'Template' -- ${REPLACE_FILES} | xargs sed -i.bak "s/Template/${PROV
 # shellcheck disable=SC2086
 git grep -l "upbound.io" -- "apis/v1*" | xargs sed -i.bak "s|upbound.io|${CRD_ROOT_GROUP}|g"
 # shellcheck disable=SC2086
+git grep -l "upbound.io" -- "cluster/test/setup.sh" | xargs sed -i.bak "s|upbound.io|${CRD_ROOT_GROUP}|g"
+# shellcheck disable=SC2086
 git grep -l "ujconfig\.WithRootGroup(\"${PROVIDER_NAME_LOWER}.upbound\.io\")" -- "config/provider.go" | xargs sed -i.bak "s|ujconfig.WithRootGroup(\"${PROVIDER_NAME_LOWER}.upbound.io\")|ujconfig.WithRootGroup(\"${CRD_ROOT_GROUP}\")|g"
 
 # We need to be careful while replacing "template" keyword in go.mod as it could tamper


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->


### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #
* fix missing EOF in cluster/test/setup.sh
* wait for provider.pkg and deployment readiness
* use root CRD for providerConfig API group versus upbound.io

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
./hack/prepare.sh
```
and verifying correct contents of `cluster/test/setup.sh`.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
