### PR TITLE
fix: Remove hardcoded build_args

### DIFF
--- a/cluster/images/upjet-provider-template/Makefile
+++ b/cluster/images/upjet-provider-template/Makefile
@@ -13,7 +13,7 @@ include ../../../build/makelib/imagelight.mk
 
 img.build:
 	@$(INFO) docker build $(IMAGE)
-	@$(MAKE) BUILD_ARGS="--load" img.build.shared
+	@$(MAKE) img.build.shared
 	@$(OK) docker build $(IMAGE)
 
 img.publish:


### PR DESCRIPTION


### Description of your changes

I ran into a problem when trying to streamline my workflow to build and push artifacts in a single step by setting `BUILD_ARGS` to `--push` in **ci workflow**. Despite this change, build images weren't being pushed to the registry. I later discovered that the `BUILD_ARGS` environment variable was being overwritten by a hardcoded value within the Makefile during the docker buildx process.



Fixes #
I removed the hardcoded `BUILD_ARGS` variable

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

